### PR TITLE
Update Bluem PHP library for Yearly certificate update 

### DIFF
--- a/bluem.php
+++ b/bluem.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Bluem ePayments, iDIN and eMandates integration for shortcodes and WooCommerce checkout
- * Version: 1.3.17.14
+ * Version: 1.3.17.15
  * Plugin URI: https://wordpress.org/plugins/bluem
  * Description: Bluem integration for WordPress and WooCommerce to facilitate Bluem services inside your site. Payments and eMandates payment gateway and iDIN identity verification
  * Author: Bluem Payment Services

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=7.4|>=8.0",
         "nesbot/carbon": "^2.53",
-        "bluem-development/bluem-php": "^2.2|^2.3",
+        "bluem-development/bluem-php": "2.3.2.9b",
         "symfony/polyfill-php72": "^1.22",
         "symfony/polyfill-mbstring": "v1.19.0",
         "symfony/polyfill-php80": "^1.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a355d462e7e8d733b9c5ca6b147dcb3",
+    "content-hash": "003dc79420d467cb91e653fcc0aba878",
     "packages": [
         {
             "name": "bluem-development/bluem-php",
-            "version": "2.3.2.8",
+            "version": "2.3.2.9b",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluem-development/bluem-php.git",
-                "reference": "2441a00cc9cdd6099f136bf9bc00f6c816f8853f"
+                "reference": "21c0735e70d3248c266d3fa0541083484e6b610f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bluem-development/bluem-php/zipball/2441a00cc9cdd6099f136bf9bc00f6c816f8853f",
-                "reference": "2441a00cc9cdd6099f136bf9bc00f6c816f8853f",
+                "url": "https://api.github.com/repos/bluem-development/bluem-php/zipball/21c0735e70d3248c266d3fa0541083484e6b610f",
+                "reference": "21c0735e70d3248c266d3fa0541083484e6b610f",
                 "shasum": ""
             },
             "require": {
@@ -71,9 +71,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bluem-development/bluem-php",
-                "source": "https://github.com/bluem-development/bluem-php/tree/2.3.2.8"
+                "source": "https://github.com/bluem-development/bluem-php/tree/2.3.2.9b"
             },
-            "time": "2023-10-18T23:56:47+00:00"
+            "time": "2024-06-26T10:13:00+00:00"
         },
         {
             "name": "erusev/parsedown",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Bluem,Payments,iDIN,iDEAL,Incassomachtigen,woocommerce, bluem, payment gat
 Requires at least: 5.0
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.3.17.14
+Stable tag: 1.3.17.15
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -74,6 +74,7 @@ Shortcode: `[bluem_identificatieformulier]`
 It is possible to programmatically block display and functionality on your site based on the verification status. Please contact us if you are interested in developing this in your site.
 
 == Changelog ==
+- 1.3.17.15: Webhook certificate update (yearly refresh)
 - 1.3.17.14: Stability fixes.
 - 1.3.17.13: Stability fixes.
 - 1.3.17.12: Stability fixes and improvements.


### PR DESCRIPTION
Require new version of Bluem-PHP (2.3.2.9b) with new webhook certificate