### PR TITLE
chore: update bluem-php dependency to version 2.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "bluem-development/bluem-php": "2.3.3",
+        "bluem-development/bluem-php": "2.3.5",
         "ext-json": "*"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84bfe2dfbbec640e5939a6eaef1743c9",
+    "content-hash": "6212ed80e2a0e08754c9990f26789cdf",
     "packages": [
         {
             "name": "bluem-development/bluem-php",
-            "version": "2.3.3",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluem-development/bluem-php.git",
-                "reference": "21c0735e70d3248c266d3fa0541083484e6b610f"
+                "reference": "7cb2e019bea85dd767c47bd21081960373ef276f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bluem-development/bluem-php/zipball/21c0735e70d3248c266d3fa0541083484e6b610f",
-                "reference": "21c0735e70d3248c266d3fa0541083484e6b610f",
+                "url": "https://api.github.com/repos/bluem-development/bluem-php/zipball/7cb2e019bea85dd767c47bd21081960373ef276f",
+                "reference": "7cb2e019bea85dd767c47bd21081960373ef276f",
                 "shasum": ""
             },
             "require": {
@@ -36,14 +36,14 @@
                 "phpspec/prophecy": "~1.0",
                 "phpunit/phpunit": "^9.5",
                 "rector/rector": "^0.15.10",
-                "roave/security-advisories": "dev-latest",
                 "squizlabs/php_codesniffer": "^3.7",
                 "vlucas/phpdotenv": "^5.4"
             },
             "type": "package",
             "autoload": {
                 "psr-4": {
-                    "Bluem\\BluemPHP\\": "src/"
+                    "Bluem\\BluemPHP\\": "src/",
+                    "Bluem\\BluemPHP\\Tests\\": "tests/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -71,9 +71,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bluem-development/bluem-php",
-                "source": "https://github.com/bluem-development/bluem-php/tree/2.3.3"
+                "source": "https://github.com/bluem-development/bluem-php/tree/2.3.5"
             },
-            "time": "2024-06-26T10:13:00+00:00"
+            "time": "2025-07-16T13:41:13+00:00"
         },
         {
             "name": "selective/xmldsig",
@@ -6100,13 +6100,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.0",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request updates the `composer.json` file to upgrade the `bluem-development/bluem-php` dependency from version `2.3.3` to `2.3.5`. This change ensures compatibility with the new webhook validation certificate change in https://github.com/bluem-development/bluem-php/releases/tag/2.3.5