### PR TITLE
New release | PHP to 2.3.8

### DIFF
--- a/bluem.php
+++ b/bluem.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: Bluem ePayments, iDIN, eMandates services and integration for WooCommerce
- * Version: 1.3.27
+ * Version: 1.3.28
  * Plugin URI: https://bluem.nl/en/
  * Description: Bluem integration for WordPress and WooCommerce for Payments, eMandates, iDIN identity verification and more
  * Author: Bluem Payment Services

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "bluem-development/bluem-php": "2.3.7",
+        "bluem-development/bluem-php": "2.3.8",
         "ext-json": "*"
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72ee310b717b9b068d12e4483c5ffdc3",
+    "content-hash": "2efe3d1e0ea124d57cbd40ff4452f496",
     "packages": [
         {
             "name": "bluem-development/bluem-php",
-            "version": "2.3.7",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluem-development/bluem-php.git",
-                "reference": "8de2cb0cd87c3a2e8cf403df92b854dc300f5d45"
+                "reference": "bfb02e83d5a99d73cdd94f190fbb7fba545fb2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bluem-development/bluem-php/zipball/8de2cb0cd87c3a2e8cf403df92b854dc300f5d45",
-                "reference": "8de2cb0cd87c3a2e8cf403df92b854dc300f5d45",
+                "url": "https://api.github.com/repos/bluem-development/bluem-php/zipball/bfb02e83d5a99d73cdd94f190fbb7fba545fb2aa",
+                "reference": "bfb02e83d5a99d73cdd94f190fbb7fba545fb2aa",
                 "shasum": ""
             },
             "require": {
@@ -71,9 +71,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bluem-development/bluem-php",
-                "source": "https://github.com/bluem-development/bluem-php/tree/2.3.7"
+                "source": "https://github.com/bluem-development/bluem-php/tree/2.3.8"
             },
-            "time": "2025-07-16T14:54:23+00:00"
+            "time": "2025-07-16T20:21:01+00:00"
         },
         {
             "name": "selective/xmldsig",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Bluem,Payments,iDIN,iDEAL,eMandates
 Requires at least: 5.0
 Tested up to: 6.6
 Requires PHP: 8.0
-Stable tag: 1.3.27
+Stable tag: 1.3.28
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -77,6 +77,7 @@ Shortcode: `[bluem_identificatieformulier]`
 It is possible to programmatically block display and functionality on your site based on the verification status. Please contact us if you are interested in developing this in your site.
 
 == Changelog ==
+- 1.3.28: Refactor SNS to ASN and update BIC list
 - 1.3.27: Certificate update (yearly refresh)
 - 1.3.26: Stability fixes and improvements for Contact Form integration
 - 1.3.25: Added refresh rewrite rule tooling


### PR DESCRIPTION
This pull request updates the Bluem plugin to version 1.3.28, including dependency updates, version bumps, and a changelog entry for the new release. The most important changes are grouped below.

### Version Updates:
* Updated the plugin version to `1.3.28` in `bluem.php` and `readme.txt` to reflect the new release. [[1]](diffhunk://#diff-8d611bf0dc46e35d060e6183317c9d87af895919738560dfdb735fc0c0c04624L5-R5) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)

### Dependency Updates:
* Updated the `bluem-development/bluem-php` dependency from version `2.3.7` to `2.3.8` in `composer.json`.

### Changelog Update:
* Added a changelog entry for version `1.3.28`, noting the refactor of SNS to ASN and the update of the BIC list.